### PR TITLE
Refactor, fix tests for new versions of natasha and yargy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r requirements.txt
   - bash bin/post_compile
 script:
-  - pytest -vv playground
+  - pytest -vv --pep8 playground

--- a/playground/settings.py
+++ b/playground/settings.py
@@ -4,14 +4,16 @@ from urllib.parse import urlparse
 
 from natasha import (
     NamesExtractor,
-    LocationExtractor,
     AddressExtractor,
+    DatesExtractor,
+    MoneyExtractor,
 )
 
 EXTRACTORS = [
     NamesExtractor(),
-    LocationExtractor(),
     AddressExtractor(),
+    DatesExtractor(),
+    MoneyExtractor(),
 ]
 
 BIND_HOST = environ.get('HOST', '0.0.0.0')

--- a/playground/tests/test_views.py
+++ b/playground/tests/test_views.py
@@ -29,7 +29,10 @@ async def test_version_endpoint(cli):
 
 
 async def test_extract_person_endpoint(cli):
-    response = await cli.post('/api/extract', data=WAR_AND_PEACE_TEXT)
+    response = await cli.post(
+        '/api/extract',
+        data={'text': WAR_AND_PEACE_TEXT}
+    )
     assert response.status == 200
     matches = await response.json()
 
@@ -77,7 +80,7 @@ async def test_extract_person_endpoint(cli):
     ]
 
 async def test_extract_location_and_address_endpoint(cli):
-    response = await cli.post('/api/extract', data=ADDRESS_TEXT)
+    response = await cli.post('/api/extract', data={'text': ADDRESS_TEXT})
     assert response.status == 200
     matches = await response.json()
 
@@ -95,7 +98,13 @@ async def test_extract_location_and_address_endpoint(cli):
     ]
 
 async def test_send_and_get_issues(cli):
-    response = await cli.post('/api/issues', data=WAR_AND_PEACE_TEXT)
+    response = await cli.post(
+        '/api/issues',
+        data={
+            'text': WAR_AND_PEACE_TEXT,
+            'description': None
+        }
+    )
     assert response.status == 200
     assert (await response.json()) == {
         'status': True

--- a/playground/tests/test_views.py
+++ b/playground/tests/test_views.py
@@ -9,112 +9,93 @@ def cli(loop, test_client):
     return loop.run_until_complete(test_client(app))
 
 
-@pytest.fixture
-def war_and_peace_text():
-    return '''
+WAR_AND_PEACE_TEXT = '''
     Так говорила в июле 1805 года известная Анна Павловна Шерер, фрейлина
     и приближенная императрицы Марии Феодоровны, встречая важного и чиновного
     князя Василия, первого приехавшего на ее вечер. Анна Павловна кашляла
     несколько дней, у нее был грипп, как она говорила (грипп был тогда
     новое слово, употреблявшееся только редкими)
-    '''
+'''
 
-
-@pytest.fixture
-def text_with_locations_and_addresses():
-    return '''
+ADDRESS_TEXT = '''
     В городе-герое Ленинграде, на Малой Конюшенной улице, дом 3
-    '''
+'''
 
 
 async def test_version_endpoint(cli):
     response = await cli.get('/api/version')
     assert response.status == 200
-    assert (await response.json()).keys() == {'natasha', 'yargy', 'pymorphy', 'pymorphy_dicts'}
+    assert (await response.json()).keys() == {'natasha', 'yargy', 'pymorphy'}
 
 
-async def test_extract_person_endpoint(cli, war_and_peace_text):
-    response = await cli.post('/api/extract', data={
-        'text': war_and_peace_text,
-    })
+async def test_extract_person_endpoint(cli):
+    response = await cli.post('/api/extract', data=WAR_AND_PEACE_TEXT)
     assert response.status == 200
     matches = await response.json()
 
-    assert len(matches) == 4
-    assert matches[0] == {
-        'fact': {
-            'first': 'анна',
-            'last': 'шерер',
-            'middle': 'павловна',
-            'nick': None
+    assert matches == [
+        {
+            'fact': {
+                'month': 7,
+                'year': 1805
+            },
+            'span': [20, 34],
+            'type': 'Date'
         },
-        'span': [45, 64],
-        'type': 'Name'
-    }
-    assert matches[1] == {
-        'fact': {
-            'first': 'мария',
-            'last': None,
-            'middle': 'феодоровна',
-            'nick': None
+        {
+            'fact': {
+                'first': 'анна',
+                'last': 'шерер',
+                'middle': 'павловна',
+            },
+            'span': [45, 64],
+            'type': 'Name'
         },
-        'span': [106, 122],
-        'type': 'Name'
-    }
-    assert matches[2] == {
-        'fact': {
-            'first': 'василий',
-            'last': None,
-            'middle': None,
-            'nick': None
+        {
+            'fact': {
+                'first': 'мария',
+                'middle': 'феодоровна',
+            },
+            'span': [106, 122],
+            'type': 'Name'
         },
-        'span': [163, 170],
-        'type': 'Name'
-    }
-    assert matches[3] == {
-        'fact': {
-            'first': 'анна',
-            'last': None,
-            'middle': 'павловна',
-            'nick': None
+        {
+            'fact': {
+                'first': 'василий',
+            },
+            'span': [163, 170],
+            'type': 'Name'
         },
-        'span': [205, 218],
-        'type': 'Name'
-    }
+        {
+            'fact': {
+                'first': 'анна',
+                'middle': 'павловна',
+            },
+            'span': [205, 218],
+            'type': 'Name'
+        }
+    ]
 
-
-async def test_extract_location_and_address_endpoint(cli, text_with_locations_and_addresses):
-    response = await cli.post('/api/extract', data={
-        'text': text_with_locations_and_addresses,
-    })
+async def test_extract_location_and_address_endpoint(cli):
+    response = await cli.post('/api/extract', data=ADDRESS_TEXT)
     assert response.status == 200
     matches = await response.json()
 
-    assert len(matches) == 2
-    assert matches[0] == {
-        'fact': {
-            'name': 'город-герой ленинград'
-        },
-        'span': [7, 30],
-        'type': 'Location',
-    }
-    assert matches[1] == {
-        'fact': {
-            'parts': [
-                {'name': 'Малой Конюшенной', 'type': 'улица'},
-                {'number': 3, 'type': 'дом'}
-            ]
-        },
-        'span': [35, 64],
-        'type': 'Address',
-    }
+    assert matches == [
+        {
+            'fact': {
+                'parts': [
+                    {'name': 'Малой Конюшенной', 'type': 'улица'},
+                    {'number': '3', 'type': 'дом'}
+                ]
+            },
+            'span': [35, 64],
+            'type': 'Address',
+        }
+    ]
 
-
-async def test_send_and_get_issues(cli, war_and_peace_text):
-    response = await cli.post('/api/issues', data={
-        'text': war_and_peace_text,
-        'description': 'some error description',
-    })
+async def test_send_and_get_issues(cli):
+    response = await cli.post('/api/issues', data=WAR_AND_PEACE_TEXT)
     assert response.status == 200
     assert (await response.json()) == {
         'status': True
@@ -122,4 +103,4 @@ async def test_send_and_get_issues(cli, war_and_peace_text):
 
     response = await cli.get('/api/issues')
     assert response.status == 200
-    assert (await response.json())[0]['text'] == war_and_peace_text
+    assert (await response.json())[0]['text'] == WAR_AND_PEACE_TEXT

--- a/playground/utils.py
+++ b/playground/utils.py
@@ -1,6 +1,19 @@
 
-from json import dumps
-from functools import partial
+import json
+
+from aiohttp import web
 
 
-json_dumps = partial(dumps, ensure_ascii=False)
+def dumps(data):
+    return json.dumps(
+        data,
+        indent=2,
+        ensure_ascii=False
+    )
+
+
+def jsonify(data):
+    return web.json_response(
+        data,
+        dumps=dumps
+    )

--- a/playground/views.py
+++ b/playground/views.py
@@ -1,74 +1,81 @@
+
 from hashlib import sha256
 from datetime import datetime
+from collections import namedtuple
 
 from yargy import __version__ as yargy_version
 from natasha import __version__ as natasha_version
 from pymorphy2 import __version__ as pymorphy_version
-from pymorphy2_dicts_ru import __version__ as pymorphy_dicts_version
 
-from aiohttp import web
+from playground.settings import (
+    EXTRACTORS,
+    REDIS_ISSUES_KEY,
+    REDIS_ISSUES_TTL
+)
+from playground.utils import jsonify
 
-from playground.settings import *
-from playground.utils import json_dumps
+
+class Issue(namedtuple('Issue', 'id, timestamp, text')):
+    @classmethod
+    def from_text(cls, text):
+        return cls(
+            id=sha256(text.encode('utf8')).hexdigest(),
+            timestamp=datetime.now(),
+            text=text
+        )
+
+    @property
+    def as_json(self):
+        return {
+            '_id': self.id,
+            'timestamp': self.timestamp.strftime('%Y-%m-%d %H:%M:%S'),
+            'text': self.text
+        }
+
+    @classmethod
+    def from_blob(cls, data):
+        return cls(
+            id=data[b'_id'].decode('utf8'),
+            timestamp=datetime.strptime(
+                data[b'timestamp'].decode('utf8'),
+                '%Y-%m-%d %H:%M:%S'
+            ),
+            text=data[b'text'].decode('utf8')
+        )
 
 
 async def extract(request):
-    form = await request.post()
+    text = await request.text()
     matches = []
     for extractor in EXTRACTORS:
-        matches.extend(extractor(form['text']).as_json)
-    return web.json_response(
-        matches,
-        dumps=json_dumps
-    )
+        matches.extend(extractor(text).as_json)
+    matches = sorted(matches, key=lambda _: _['span'])
+    return jsonify(matches)
 
 
 def version(request):
-    return web.json_response({
+    return jsonify({
         'yargy': yargy_version,
         'natasha': natasha_version,
         'pymorphy': pymorphy_version,
-        'pymorphy_dicts': pymorphy_dicts_version,
     })
 
 
 async def get_issues(request):
     async with request.app.redis.get() as conn:
-        items = await conn.keys('{0}:*'.format(REDIS_ISSUES_KEY))
-        items = [await conn.hgetall(_id) for _id in items]
-        items = [
-            {
-                '_id': item[b'_id'].decode('utf-8'),
-                'text': item[b'text'].decode('utf-8'),
-                'description': item[b'description'].decode('utf-8'),
-                'datetime': item[b'datetime'].decode('utf-8'),
-            } for item in items
-        ]
-        return web.json_response(
-            items,
-            dumps=json_dumps,
-        )
+        ids = await conn.keys('{0}:*'.format(REDIS_ISSUES_KEY))
+        items = [await conn.hgetall(_) for _ in ids]
+        items = [Issue.from_blob(_).as_json for _ in items]
+        return jsonify(items)
+
 
 async def send_issue(request):
-    form = await request.post()
-    text = form['text']
-    description = form['description']
-    _id = sha256(text.encode('utf-8')).hexdigest()
+    text = await request.text()
     async with request.app.redis.get() as conn:
-        key = '{0}:{1}'.format(REDIS_ISSUES_KEY, _id)
-        await conn.hmset_dict(
-            key,
-            {
-                '_id': _id,
-                'text': text,
-                'description': description,
-                'datetime': str(datetime.now()),
-            }
-        )
+        item = Issue.from_text(text)
+        key = '{0}:{1}'.format(REDIS_ISSUES_KEY, item.id)
+        await conn.hmset_dict(key, item.as_json)
         await conn.expire(key, REDIS_ISSUES_TTL)
-    return web.json_response(
-        {
-            'status': True,
-        },
-        dumps=json_dumps,
-    )
+    return jsonify({
+        'status': True
+    })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pymorphy2[fast]
-ujson
 aiohttp==2.0.7
 aiohttp-cors==0.5.3
 aioredis==0.3.3
 pytest==3.0.7
+pytest-pep8==1.0.6
 pytest-aiohttp==0.1.3


### PR DESCRIPTION
В патче сделан рефакторинг `get_issues`, `send_issue`, введён объект `Issue`

Ещё предлагаю перенести playground в github.com/natasha/playground. А демо b-labs.pro/natasha продублировать на natasha.github.io/demo . Интерфейс можно сделать более продвинутый:
![image](https://user-images.githubusercontent.com/153776/37257478-0de4cb26-257b-11e8-8d10-e47592df43de.png)
1. Обработка по shift-enter, не надо отрывать руки от клавиатуры
2. Выделение подчёркиванием. Такое оформление позволяет выделять пересекающиеся факты ![image](https://user-images.githubusercontent.com/153776/37257550-144789ee-257c-11e8-87e9-b0a8bcdfdd79.png) . В моей практике была такая необходимость
3. Json с фактами . Можно посмотреть, например, к какой нормальной форме приведено имя
